### PR TITLE
Add FastSet OpenClaw Skill

### DIFF
--- a/skills/fastset/SKILL.md
+++ b/skills/fastset/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: fastset
+description: Interact with the FastSet network - a high-performance blockchain settlement layer. Use when submitting transactions, querying account balances, transferring tokens, minting custom tokens, or working with the FastSet JSON-RPC proxy API. Supports wallet operations with Ed25519 keys.
+---
+
+# FastSet Network Skill
+
+Interact with the FastSet network via the JSON-RPC proxy API at `https://proxy.fastset.xyz`.
+
+## Quick Reference
+
+| Operation | Endpoint | Use Case |
+|-----------|----------|----------|
+| Get account info | `proxy_getAccountInfo` | Check balance, nonce, state |
+| Submit transaction | `proxy_submitTransaction` | Transfer tokens, create tokens, etc. |
+| Faucet (testnet) | `proxy_faucetDrip` | Get test tokens |
+| Get token info | `proxy_getTokenInfo` | Query custom token metadata |
+
+## Core Concepts
+
+- **Addresses**: 32-byte Ed25519 public keys (hex-encoded as 64 chars)
+- **Nonce**: Auto-incrementing u64 per account (start at 0)
+- **Amounts**: Hex-encoded 256-bit integers (e.g., `"ffff"` = 65535)
+- **Native Token ID**: `FA575E7000000000000000000000000000000000000000000000000000000000`
+- **Signatures**: Ed25519 over BCS-serialized transaction with `"Transaction::"` prefix
+
+## Common Operations
+
+### 1. Query Account Balance
+
+```bash
+curl -X POST https://proxy.fastset.xyz \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "proxy_getAccountInfo",
+    "params": {
+      "address": [/* 32-byte array */],
+      "token_balance_filter": null,
+      "certificate_by_nonce": null
+    }
+  }'
+```
+
+Response includes `balance` (hex string), `next_nonce`, and `token_balance` array.
+
+### 2. Get Test Tokens (Faucet)
+
+```bash
+curl -X POST https://proxy.fastset.xyz \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "proxy_faucetDrip",
+    "params": {
+      "recipient": [/* 32-byte array */],
+      "amount": "de0b6b3a7640000",
+      "token_id": null
+    }
+  }'
+```
+
+### 3. Transfer Tokens
+
+Build a transaction with claim type `TokenTransfer`:
+
+```json
+{
+  "sender": [/* 32-byte pubkey */],
+  "recipient": [/* 32-byte pubkey */],
+  "nonce": 0,
+  "timestamp_nanos": 1700000000000000000,
+  "archival": false,
+  "claim": {
+    "TokenTransfer": {
+      "token_id": [/* 32-byte token ID */],
+      "amount": "ffff",
+      "user_data": null
+    }
+  }
+}
+```
+
+Sign with Ed25519 over: `"Transaction::" + BCS(transaction)`
+
+Submit via `proxy_submitTransaction` with `{ transaction, signature: { Signature: [/* 64 bytes */] } }`.
+
+## Claim Types
+
+| Type | Purpose |
+|------|---------|
+| `TokenTransfer` | Transfer tokens between accounts |
+| `TokenCreation` | Create new custom token |
+| `TokenManagement` | Modify token (admin, minters) |
+| `Mint` | Mint additional supply (authorized minters) |
+| `ExternalClaim` | Submit arbitrary data with verifier signatures |
+| `Batch` | Bundle multiple operations |
+
+## Transaction Signing (TypeScript)
+
+```typescript
+import { bcs } from "@mysten/bcs";
+import * as ed from "@noble/ed25519";
+
+// Define BCS schema for Transaction (see typescript-examples/fastset-types.ts)
+const msghead = new TextEncoder().encode("Transaction::");
+const msgbody = TransactionBcs.serialize(transaction).toBytes();
+const msg = new Uint8Array(msghead.length + msgbody.length);
+msg.set(msghead, 0);
+msg.set(msgbody, msghead.length);
+const signature = ed.sign(msg, privateKey);
+```
+
+## Transaction Signing (Rust)
+
+Use the `bcs` crate with `serde` for serialization. See `rust-examples/` for complete implementation.
+
+## Wallet Management
+
+### Generate New Keypair
+
+```typescript
+import * as ed from "@noble/ed25519";
+const privateKey = ed.utils.randomPrivateKey(); // 32 bytes
+const publicKey = ed.getPublicKey(privateKey);  // 32 bytes = address
+```
+
+### Store Private Key Securely
+
+Store as hex string in environment variable or secure vault:
+```bash
+export FASTSET_PRIVATE_KEY="your_64_char_hex_private_key"
+```
+
+## Working Examples
+
+Complete working examples are available:
+- **TypeScript**: `typescript-examples/` - Run with `npm install && npm run start`
+- **Rust**: `rust-examples/` - Run with `cargo run`
+
+Both demonstrate: key generation → faucet funding → transaction signing → submission.
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Invalid nonce | Wrong sequence number | Fetch `next_nonce` from `proxy_getAccountInfo` |
+| Insufficient balance | Not enough tokens | Use faucet or receive transfer first |
+| Invalid signature | Wrong signing process | Ensure BCS encoding with `"Transaction::"` prefix |
+
+## API Reference
+
+See `docs/proxy/rpc.md` for complete JSON-RPC specification including all data types and schemas.

--- a/skills/fastset/SKILL.md
+++ b/skills/fastset/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: fastset
-description: Interact with the FastSet network - a high-performance blockchain settlement layer. Use when submitting transactions, querying account balances, transferring tokens, minting custom tokens, or working with the FastSet JSON-RPC proxy API. Supports wallet operations with Ed25519 keys.
+version: 1.0.0
+description: Interact with the FastSet network — a high-performance settlement layer. Query accounts, submit transactions, transfer and mint tokens via the JSON-RPC proxy API. Supports Ed25519 wallet operations.
+author: Pi-Squared-Inc
+homepage: https://github.com/Pi-Squared-Inc/fastset-rpc-docs
 ---
 
 # FastSet Network Skill

--- a/skills/fastset/SKILL.md
+++ b/skills/fastset/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fastset
-version: 1.1.0
+version: 1.2.0
 description: Interact with the FastSet network — a high-performance settlement layer. Query accounts, submit transactions, transfer and mint tokens via the JSON-RPC proxy API. Supports Ed25519 wallet operations.
 author: Pi-Squared-Inc
 homepage: https://github.com/Pi-Squared-Inc/fastset-rpc-docs
@@ -8,81 +8,131 @@ homepage: https://github.com/Pi-Squared-Inc/fastset-rpc-docs
 
 # FastSet Network Skill
 
-Interact with the FastSet network via the JSON-RPC proxy API at `https://proxy.fastset.xyz`.
+> **Interact with the FastSet network** via the JSON-RPC proxy API.
 
-## Prerequisites
+> 🚨 **Base URL:** `https://proxy.fastset.xyz`
 
-**npm packages** (for TypeScript/Node.js):
+---
+
+> ⚡ **New here?** Start at [Getting Started](#getting-started) — you'll have a funded wallet in 2 minutes.
+> 📋 **Already set up?** Jump to [Quick Reference](#quick-reference).
+> 🔧 **Need to sign transactions?** See [BCS Type Definitions](#bcs-type-definitions) and [Complete Working Example](#complete-working-example).
+
+---
+
+## Quick Reference
+
+| Action | Method | Endpoint |
+|--------|--------|----------|
+| Query account | `proxy_getAccountInfo` | Check balance, nonce, state |
+| Submit transaction | `proxy_submitTransaction` | Transfer tokens, create tokens, etc. |
+| Faucet (testnet) | `proxy_faucetDrip` | Get test tokens (returns `null` on success) |
+| Token info | `proxy_getTokenInfo` | Query custom token metadata |
+
+---
+
+## Getting Started
+
+### Step 1: Install Dependencies
+
 ```bash
 npm install @mysten/bcs @noble/ed25519 @noble/hashes
 ```
 
-**Required setup** — `@noble/ed25519` needs an explicit SHA-512 implementation:
+> ⚠️ **Version note:** This skill targets `@noble/ed25519` **v3.x**. If using v2.x, see [Version Compatibility](#version-compatibility).
+
+### Step 2: Required Setup
+
+Every script needs these before using ed25519:
+
 ```typescript
 import * as ed from "@noble/ed25519";
-import { sha512 } from "@noble/hashes/sha2";
-ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
-```
+import { sha512 } from "@noble/hashes/sha2.js";
 
-**BigInt JSON serialization** workaround (needed for JSON-RPC calls):
-```typescript
+// Required: ed25519 needs explicit SHA-512
+ed.hashes.sha512 = (...m) => sha512(ed.etc.concatBytes(...m));
+
+// Required: BigInt JSON serialization workaround
 // @ts-ignore
 BigInt.prototype.toJSON = function () { return Number(this); };
 ```
 
-**Uint8Array → JSON**: When serializing `Uint8Array` to JSON, use `Array.from(bytes)` — `JSON.stringify` doesn't handle typed arrays natively:
+> ⚠️ **Import path:** Use `@noble/hashes/sha2.js` (with `.js` extension) — ESM requires it.
+
+### Step 3: Generate a Wallet
+
 ```typescript
-JSON.stringify(data, (k, v) => v instanceof Uint8Array ? Array.from(v) : v);
+const privateKey = ed.utils.randomSecretKey(); // 32 bytes
+const publicKey = ed.getPublicKey(privateKey);  // 32 bytes = your address
+console.log("Address:", Buffer.from(publicKey).toString("hex"));
 ```
 
-## Quick Reference
+### Step 4: Fund via Faucet
 
-| Operation | Endpoint | Use Case |
-|-----------|----------|----------|
-| Get account info | `proxy_getAccountInfo` | Check balance, nonce, state |
-| Submit transaction | `proxy_submitTransaction` | Transfer tokens, create tokens, etc. |
-| Faucet (testnet) | `proxy_faucetDrip` | Get test tokens |
-| Get token info | `proxy_getTokenInfo` | Query custom token metadata |
+```typescript
+await rpc("proxy_faucetDrip", {
+  recipient: publicKey,        // Uint8Array → auto-serialized to byte array
+  amount: "de0b6b3a7640000",   // 1 SET (hex string)
+  token_id: null               // null = native token
+});
+// Returns null on success!
+```
+
+### Step 5: Check Your Balance
+
+```typescript
+const info = await rpc("proxy_getAccountInfo", {
+  address: publicKey,
+  token_balances_filter: null,
+  state_key_filter: null,
+  certificate_by_nonce: null,
+});
+console.log("Balance:", info.result.balance); // hex string, e.g. "de0b6b3a7640000"
+console.log("Nonce:", info.result.next_nonce); // use as nonce for next tx
+```
+
+> The `rpc()` helper is defined in [Complete Working Example](#complete-working-example) below.
+
+---
 
 ## Core Concepts
 
 - **Addresses**: 32-byte Ed25519 public keys — sent as JSON arrays of 32 unsigned integers (byte arrays), not hex strings
-- **Nonce**: Auto-incrementing `u64` per account (start at 0). Fetch current value from `proxy_getAccountInfo` → `next_nonce`
-- **Amounts**: Hex-encoded 256-bit integers in JSON (e.g., `"ffff"` = 65535). **BCS encodes these as 32-byte little-endian u256** — the `@mysten/bcs` transform handles this automatically (see BCS Types section)
-- **Timestamps**: `timestamp_nanos` is a `u128` (use `BigInt` in TypeScript)
-- **Native Token ID**: `FA575E7000000000000000000000000000000000000000000000000000000000` (as bytes: `[0xfa, 0x57, 0x5e, 0x70, 0, 0, ..., 0]`)
+- **Nonce**: Auto-incrementing `u64` per account (start at 0). Always fetch from `proxy_getAccountInfo` → `next_nonce` before submitting
+- **Amounts**: Hex-encoded 256-bit integers in JSON (e.g., `"ffff"` = 65535). BCS encodes these as 32-byte little-endian u256 automatically
+- **Timestamps**: `timestamp_nanos` is a `u128` (use `BigInt` in TypeScript: `BigInt(Date.now()) * 1_000_000n`)
+- **Native Token ID**: `[0xfa, 0x57, 0x5e, 0x70, 0, 0, ..., 0]` (32 bytes)
 - **Signatures**: Ed25519 over `"Transaction::" + BCS(transaction)`
+- **JSON serialization**: `Uint8Array` must be converted via `Array.from()` — see helper below
+
+---
 
 ## BCS Type Definitions
 
-These are required for transaction signing. The BCS schema must match the on-chain types exactly.
+Required for transaction signing. The BCS schema **must** match on-chain types exactly.
 
 ```typescript
 import { bcs } from "@mysten/bcs";
 
-const Bytes32 = bcs.bytes(32);
-const Bytes64 = bcs.bytes(64);
-
-// Amount: hex string in JSON, but BCS encodes as u256 (32-byte LE)
+// Amount: hex string in JSON, BCS encodes as u256 (32-byte LE)
 const AmountBcs = bcs.u256().transform({
   input: (val) => BigInt(`0x${val}`).toString(), // hex → decimal for BCS
 });
 
 const TokenTransfer = bcs.struct("TokenTransfer", {
-  token_id: Bytes32,
+  token_id: bcs.bytes(32),
   amount: AmountBcs,
-  user_data: bcs.option(Bytes32),
+  user_data: bcs.option(bcs.bytes(32)),
 });
 
-// ClaimType enum — variant order matters for BCS encoding!
-// Index 0 = TokenTransfer. Other variants exist but are omitted here.
+// Variant order matters for BCS! TokenTransfer = index 0.
 const ClaimType = bcs.enum("ClaimType", {
   TokenTransfer: TokenTransfer,
 });
 
 const TransactionBcs = bcs.struct("Transaction", {
-  sender: Bytes32,
-  recipient: Bytes32,
+  sender: bcs.bytes(32),
+  recipient: bcs.bytes(32),
   nonce: bcs.u64(),
   timestamp_nanos: bcs.u128(),
   claim: ClaimType,
@@ -91,68 +141,20 @@ const TransactionBcs = bcs.struct("Transaction", {
 ```
 
 > **Important**: The `ClaimType` enum variant ordering determines the BCS discriminant byte.
-> `TokenTransfer` = index 0. If you add more variants (TokenCreation, TokenManagement, Mint, ExternalClaim, Batch),
-> they must match the on-chain ordering. See `typescript-examples/fastset-types.ts` for the complete set.
+> If you add more variants, they must match on-chain ordering. See `typescript-examples/fastset-types.ts` for the complete set.
 
-## Common Operations
+---
 
-### 1. Query Account Balance
+## Transferring Tokens
 
-```bash
-curl -X POST https://proxy.fastset.xyz \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "proxy_getAccountInfo",
-    "params": {
-      "address": [134, 108, 191, 240, ...],
-      "token_balances_filter": null,
-      "state_key_filter": null,
-      "certificate_by_nonce": null
-    }
-  }'
-```
-
-> **Note**: `address` is a JSON array of 32 unsigned integers (the bytes of the Ed25519 public key).
-> `token_balances_filter` (not `token_balance_filter`) accepts an array of token IDs or `null`.
-
-**Response fields**:
-- `balance` — hex string (e.g., `"de0b6b3a7640000"`)
-- `next_nonce` — integer, use this as nonce for the next transaction
-- `token_balances` — map of custom token balances (native balance is in `balance`, not here)
-
-### 2. Get Test Tokens (Faucet)
-
-```bash
-curl -X POST https://proxy.fastset.xyz \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "proxy_faucetDrip",
-    "params": {
-      "recipient": [134, 108, 191, 240, ...],
-      "amount": "de0b6b3a7640000",
-      "token_id": null
-    }
-  }'
-```
-
-> `recipient` is a byte array (same format as address). `amount` is a hex string.
-> `token_id` can be `null` (native token) or a 32-byte array for custom tokens.
-> **Returns `null` on success** (not a confirmation object).
-
-### 3. Transfer Tokens
-
-Build a transaction object:
+### Build the Transaction
 
 ```typescript
 const transaction = {
   sender: senderPubKey,          // Uint8Array (32 bytes)
   recipient: recipientPubKey,    // Uint8Array (32 bytes)
   nonce: nextNonce,              // number (from getAccountInfo)
-  timestamp_nanos: BigInt(Date.now()) * 1_000_000n,  // u128 nanoseconds
+  timestamp_nanos: BigInt(Date.now()) * 1_000_000n,
   claim: {
     TokenTransfer: {
       token_id: SET_TOKEN_ID,    // Uint8Array (32 bytes)
@@ -164,25 +166,27 @@ const transaction = {
 };
 ```
 
-Sign and submit:
+### Sign It
 
 ```typescript
-// Sign
 const msghead = new TextEncoder().encode("Transaction::");
 const msgbody = TransactionBcs.serialize(transaction).toBytes();
 const msg = new Uint8Array(msghead.length + msgbody.length);
 msg.set(msghead, 0);
 msg.set(msgbody, msghead.length);
 const signature = ed.sign(msg, privateKey);
-
-// Submit via JSON-RPC
-const params = {
-  transaction,
-  signature: { Signature: signature }  // wraps in enum variant
-};
-// POST to proxy with method "proxy_submitTransaction" and params above
-// Remember to use the custom JSON serializer for Uint8Array → Array.from()
 ```
+
+### Submit It
+
+```typescript
+const result = await rpc("proxy_submitTransaction", {
+  transaction,
+  signature: { Signature: signature },  // wrapped in enum variant
+});
+```
+
+---
 
 ## Claim Types
 
@@ -195,37 +199,19 @@ const params = {
 | `ExternalClaim` | 4 | Submit arbitrary data with verifier signatures |
 | `Batch` | 5 | Bundle multiple operations |
 
-## Wallet Management
-
-### Generate New Keypair
-
-```typescript
-import * as ed from "@noble/ed25519";
-import { sha512 } from "@noble/hashes/sha2";
-ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
-
-const privateKey = ed.utils.randomPrivateKey(); // 32 bytes
-const publicKey = ed.getPublicKey(privateKey);   // 32 bytes = your address
-```
-
-### Store Private Key Securely
-
-Store as hex string in environment variable or secure vault:
-```bash
-export FASTSET_PRIVATE_KEY="your_64_char_hex_private_key"
-```
+---
 
 ## Complete Working Example
 
-Self-contained Node.js example — generate wallet, fund via faucet, transfer tokens:
+Self-contained Node.js script — generates two wallets, funds one, transfers tokens to the other.
 
 ```typescript
 import * as ed from "@noble/ed25519";
-import { sha512 } from "@noble/hashes/sha2";
+import { sha512 } from "@noble/hashes/sha2.js";
 import { bcs } from "@mysten/bcs";
 
-// Setup
-ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
+// ── Setup ──────────────────────────────────────────────
+ed.hashes.sha512 = (...m) => sha512(ed.etc.concatBytes(...m));
 // @ts-ignore
 BigInt.prototype.toJSON = function () { return Number(this); };
 
@@ -233,7 +219,7 @@ const PROXY = "https://proxy.fastset.xyz";
 const SET_TOKEN_ID = new Uint8Array(32);
 SET_TOKEN_ID.set([0xfa, 0x57, 0x5e, 0x70], 0);
 
-// BCS types (minimal for TokenTransfer)
+// ── BCS Types ──────────────────────────────────────────
 const AmountBcs = bcs.u256().transform({
   input: (val) => BigInt(`0x${val}`).toString(),
 });
@@ -247,56 +233,128 @@ const TransactionBcs = bcs.struct("Transaction", {
   claim: ClaimType, archival: bcs.bool(),
 });
 
-// Helpers
-const toJSON = (data: any) => JSON.stringify(data, (k, v) =>
+// ── JSON Helper (Uint8Array → Array) ───────────────────
+const toJSON = (data) => JSON.stringify(data, (k, v) =>
   v instanceof Uint8Array ? Array.from(v) : v);
 
-async function rpc(method: string, params: any) {
+// ── RPC Helper ─────────────────────────────────────────
+async function rpc(method, params) {
   const res = await fetch(PROXY, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: toJSON({ jsonrpc: "2.0", id: 1, method, params }),
   });
-  return res.json();
+  const json = await res.json();
+  if (json.error) throw new Error(`RPC error: ${JSON.stringify(json.error)}`);
+  return json;
 }
 
-// 1. Generate keypairs
-const sk1 = ed.utils.randomPrivateKey();
+// ── 1. Generate two wallets ────────────────────────────
+const sk1 = ed.utils.randomSecretKey();
 const pk1 = ed.getPublicKey(sk1);
-const sk2 = ed.utils.randomPrivateKey();
+const sk2 = ed.utils.randomSecretKey();
 const pk2 = ed.getPublicKey(sk2);
+console.log("Wallet 1:", Buffer.from(pk1).toString("hex"));
+console.log("Wallet 2:", Buffer.from(pk2).toString("hex"));
 
-// 2. Fund sender via faucet
+// ── 2. Fund wallet 1 via faucet ────────────────────────
 await rpc("proxy_faucetDrip", { recipient: pk1, amount: "de0b6b3a7640000", token_id: null });
+console.log("Faucet: funded wallet 1");
 
-// 3. Check balance & nonce
+// ── 3. Check balance & nonce ───────────────────────────
 const info = await rpc("proxy_getAccountInfo", {
   address: pk1, token_balances_filter: null, state_key_filter: null, certificate_by_nonce: null,
 });
-console.log("Balance:", info.result.balance, "Nonce:", info.result.next_nonce);
+console.log("Balance:", info.result.balance, "| Nonce:", info.result.next_nonce);
 
-// 4. Build, sign, and submit a transfer
+// ── 4. Build transfer transaction ──────────────────────
 const tx = {
   sender: pk1, recipient: pk2, nonce: info.result.next_nonce,
   timestamp_nanos: BigInt(Date.now()) * 1_000_000n,
   claim: { TokenTransfer: { token_id: SET_TOKEN_ID, amount: "ffff", user_data: null } },
   archival: false,
 };
+
+// ── 5. Sign ────────────────────────────────────────────
 const head = new TextEncoder().encode("Transaction::");
 const body = TransactionBcs.serialize(tx).toBytes();
 const msg = new Uint8Array(head.length + body.length);
 msg.set(head, 0); msg.set(body, head.length);
 const sig = ed.sign(msg, sk1);
 
+// ── 6. Submit ──────────────────────────────────────────
 const result = await rpc("proxy_submitTransaction", {
   transaction: tx, signature: { Signature: sig },
 });
-console.log("Transfer result:", result);
+console.log("Transfer submitted:", result.result ? "✅ success" : "❌ failed");
+
+// ── 7. Verify balances ────────────────────────────────
+const info1 = await rpc("proxy_getAccountInfo", {
+  address: pk1, token_balances_filter: null, state_key_filter: null, certificate_by_nonce: null,
+});
+const info2 = await rpc("proxy_getAccountInfo", {
+  address: pk2, token_balances_filter: null, state_key_filter: null, certificate_by_nonce: null,
+});
+console.log("Wallet 1 balance:", info1.result.balance);
+console.log("Wallet 2 balance:", info2.result.balance);
 ```
 
-## Transaction Signing (Rust)
+---
 
-Use the `bcs` crate with `serde` for serialization. See `rust-examples/` for complete implementation.
+## Version Compatibility
+
+### `@noble/ed25519` v2.x vs v3.x
+
+| Feature | v2.x | v3.x (current) |
+|---------|------|-----------------|
+| Import SHA-512 | `@noble/hashes/sha2` | `@noble/hashes/sha2.js` |
+| Set SHA-512 | `ed.etc.sha512Sync = ...` | `ed.hashes.sha512 = ...` |
+| Generate key | `ed.utils.randomPrivateKey()` | `ed.utils.randomSecretKey()` |
+| Get public key | `ed.getPublicKey(sk)` | `ed.getPublicKey(sk)` (same) |
+| Sign | `ed.sign(msg, sk)` | `ed.sign(msg, sk)` (same) |
+
+To pin v2: `npm install @noble/ed25519@2 @noble/hashes@1`
+
+---
+
+## curl Examples
+
+### Query Account
+
+```bash
+curl -s -X POST https://proxy.fastset.xyz \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0", "id": 1,
+    "method": "proxy_getAccountInfo",
+    "params": {
+      "address": [134, 108, 191, 240, 166, 239, 50, ...],
+      "token_balances_filter": null,
+      "state_key_filter": null,
+      "certificate_by_nonce": null
+    }
+  }'
+```
+
+### Faucet Drip
+
+```bash
+curl -s -X POST https://proxy.fastset.xyz \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0", "id": 1,
+    "method": "proxy_faucetDrip",
+    "params": {
+      "recipient": [134, 108, 191, 240, 166, 239, 50, ...],
+      "amount": "de0b6b3a7640000",
+      "token_id": null
+    }
+  }'
+```
+
+> Both `address` and `recipient` are JSON arrays of 32 unsigned integers (byte values of the Ed25519 public key).
+
+---
 
 ## Error Handling
 
@@ -304,9 +362,15 @@ Use the `bcs` crate with `serde` for serialization. See `rust-examples/` for com
 |-------|-------|-----|
 | Invalid nonce | Wrong sequence number | Fetch `next_nonce` from `proxy_getAccountInfo` |
 | Insufficient balance | Not enough tokens | Use faucet or receive transfer first |
-| Invalid signature | Wrong signing process | Ensure BCS encoding with `"Transaction::"` prefix |
-| `No more params` | Missing required RPC parameters | Check all required fields are present |
+| Invalid signature | Wrong signing process | Ensure `"Transaction::" + BCS(tx)` prefix |
+| `No more params` | Missing required RPC fields | Check all required params are present |
+
+---
+
+## Rust
+
+Use the `bcs` crate with `serde` for serialization. See `rust-examples/` for a complete implementation.
 
 ## API Reference
 
-See `docs/proxy/rpc.md` for complete JSON-RPC specification including all data types and schemas.
+Full JSON-RPC specification: `docs/proxy/rpc.md`

--- a/skills/fastset/SKILL.md
+++ b/skills/fastset/SKILL.md
@@ -21,11 +21,11 @@ Interact with the FastSet network via the JSON-RPC proxy API at `https://proxy.f
 
 ## Core Concepts
 
-- **Addresses**: 32-byte Ed25519 public keys (hex-encoded as 64 chars)
+- **Addresses**: 32-byte Ed25519 public keys — sent as JSON arrays of 32 unsigned integers (byte arrays), not hex strings
 - **Nonce**: Auto-incrementing u64 per account (start at 0)
 - **Amounts**: Hex-encoded 256-bit integers (e.g., `"ffff"` = 65535)
 - **Native Token ID**: `FA575E7000000000000000000000000000000000000000000000000000000000`
-- **Signatures**: Ed25519 over BCS-serialized transaction with `"Transaction::"` prefix
+- **Signatures**: Ed25519 over `"Transaction::" + BCS(transaction)` (BCS encodes Amount/Balance fields as 32-byte little-endian u256)
 
 ## Common Operations
 
@@ -39,14 +39,18 @@ curl -X POST https://proxy.fastset.xyz \
     "id": 1,
     "method": "proxy_getAccountInfo",
     "params": {
-      "address": [/* 32-byte array */],
-      "token_balance_filter": null,
+      "address": [134, 108, 191, 240, ...],
+      "token_balances_filter": null,
+      "state_key_filter": null,
       "certificate_by_nonce": null
     }
   }'
 ```
 
-Response includes `balance` (hex string), `next_nonce`, and `token_balance` array.
+> **Note**: `address` is a JSON array of 32 unsigned integers (the bytes of the Ed25519 public key).  
+> `token_balances_filter` (not `token_balance_filter`) accepts an array of token IDs or `null`.
+
+Response includes `balance` (hex string), `next_nonce`, and `token_balances` map.
 
 ### 2. Get Test Tokens (Faucet)
 
@@ -58,12 +62,16 @@ curl -X POST https://proxy.fastset.xyz \
     "id": 1,
     "method": "proxy_faucetDrip",
     "params": {
-      "recipient": [/* 32-byte array */],
+      "recipient": [134, 108, 191, 240, ...],
       "amount": "de0b6b3a7640000",
       "token_id": null
     }
   }'
 ```
+
+> **Note**: `recipient` is a byte array (same format as address). `amount` is a hex string.  
+> `token_id` can be `null` (native token) or a 32-byte array for custom tokens.  
+> Returns `null` on success.
 
 ### 3. Transfer Tokens
 
@@ -126,8 +134,8 @@ Use the `bcs` crate with `serde` for serialization. See `rust-examples/` for com
 
 ```typescript
 import * as ed from "@noble/ed25519";
-const privateKey = ed.utils.randomPrivateKey(); // 32 bytes
-const publicKey = ed.getPublicKey(privateKey);  // 32 bytes = address
+const privateKey = ed.utils.randomPrivateKey(); // 32 bytes (or randomSecretKey() in newer versions)
+const publicKey = await ed.getPublicKeyAsync(privateKey); // 32 bytes = address
 ```
 
 ### Store Private Key Securely

--- a/skills/fastset/SKILL.md
+++ b/skills/fastset/SKILL.md
@@ -91,6 +91,18 @@ console.log("Balance:", info.result.balance); // hex string, e.g. "de0b6b3a76400
 console.log("Nonce:", info.result.next_nonce); // use as nonce for next tx
 ```
 
+**Response fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `balance` | hex string | Native token balance (e.g., `"de0b6b3a7640000"`) |
+| `next_nonce` | integer | Next valid nonce for transactions |
+| `token_balances` | object | Custom token balances (native balance is in `balance`) |
+| `sender` | array | Account address echo |
+| `pending_confirmation` | number | Pending transaction count |
+| `requested_state` | object/null | Account state if requested |
+| `requested_certificates` | array | Certificates if requested by nonce |
+
 > The `rpc()` helper is defined in [Complete Working Example](#complete-working-example) below.
 
 ---
@@ -364,6 +376,10 @@ curl -s -X POST https://proxy.fastset.xyz \
 | Insufficient balance | Not enough tokens | Use faucet or receive transfer first |
 | Invalid signature | Wrong signing process | Ensure `"Transaction::" + BCS(tx)` prefix |
 | `No more params` | Missing required RPC fields | Check all required params are present |
+| `sha512` / `hashes.sha512` not set | Missing ed25519 setup | Add `ed.hashes.sha512 = ...` (see Step 2) |
+| BigInt serialization error | `JSON.stringify` can't handle BigInt | Add `BigInt.prototype.toJSON` (see Step 2) |
+| Address serialized as object | `Uint8Array` not converted for JSON | Use `Array.from()` or `toJSON` helper |
+| Faucet returns `null` | **This is success**, not an error | Check `json.error` field for real errors |
 
 ---
 

--- a/skills/fastset/SKILL.md
+++ b/skills/fastset/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fastset
-version: 1.2.0
+version: 1.3.0
 description: Interact with the FastSet network — a high-performance settlement layer. Query accounts, submit transactions, transfer and mint tokens via the JSON-RPC proxy API. Supports Ed25519 wallet operations.
 author: Pi-Squared-Inc
 homepage: https://github.com/Pi-Squared-Inc/fastset-rpc-docs
@@ -36,9 +36,12 @@ homepage: https://github.com/Pi-Squared-Inc/fastset-rpc-docs
 ### Step 1: Install Dependencies
 
 ```bash
+npm init -y  # if starting fresh
+npm pkg set type=module  # required for ESM imports
 npm install @mysten/bcs @noble/ed25519 @noble/hashes
 ```
 
+> ⚠️ **ESM required:** Your `package.json` must have `"type": "module"` (or use `.mjs` file extension).
 > ⚠️ **Version note:** This skill targets `@noble/ed25519` **v3.x**. If using v2.x, see [Version Compatibility](#version-compatibility).
 
 ### Step 2: Required Setup
@@ -97,11 +100,12 @@ console.log("Nonce:", info.result.next_nonce); // use as nonce for next tx
 |-------|------|-------------|
 | `balance` | hex string | Native token balance (e.g., `"de0b6b3a7640000"`) |
 | `next_nonce` | integer | Next valid nonce for transactions |
-| `token_balances` | object | Custom token balances (native balance is in `balance`) |
+| `token_balance` | array | Custom token balances (native balance is in `balance`) |
 | `sender` | array | Account address echo |
-| `pending_confirmation` | number | Pending transaction count |
-| `requested_state` | object/null | Account state if requested |
+| `pending_confirmation` | number/null | Pending transaction count (`null` for new accounts) |
+| `requested_state` | array | Account state if requested (empty array `[]` by default) |
 | `requested_certificates` | array | Certificates if requested by nonce |
+| `requested_validated_transaction` | object/null | Validated transaction if requested |
 
 > The `rpc()` helper is defined in [Complete Working Example](#complete-working-example) below.
 
@@ -115,6 +119,7 @@ console.log("Nonce:", info.result.next_nonce); // use as nonce for next tx
 - **Timestamps**: `timestamp_nanos` is a `u128` (use `BigInt` in TypeScript: `BigInt(Date.now()) * 1_000_000n`)
 - **Native Token ID**: `[0xfa, 0x57, 0x5e, 0x70, 0, 0, ..., 0]` (32 bytes)
 - **Signatures**: Ed25519 over `"Transaction::" + BCS(transaction)`
+- **Transaction fees**: Transfers incur a fee (~0.01 SET). The sender's balance decreases by the transfer amount **plus** the fee
 - **JSON serialization**: `Uint8Array` must be converted via `Array.from()` — see helper below
 
 ---
@@ -196,7 +201,11 @@ const result = await rpc("proxy_submitTransaction", {
   transaction,
   signature: { Signature: signature },  // wrapped in enum variant
 });
+// On success: result.result = { Success: { envelope: {...}, signatures: [...] } }
+// The envelope contains your transaction + signature; signatures are validator confirmations
 ```
+
+> **Note:** Transactions incur a fee (~0.01 SET). The sender's balance will decrease by the transfer amount **plus** the fee.
 
 ---
 

--- a/skills/fastset/SKILL.md
+++ b/skills/fastset/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fastset
-version: 1.0.0
+version: 1.1.0
 description: Interact with the FastSet network — a high-performance settlement layer. Query accounts, submit transactions, transfer and mint tokens via the JSON-RPC proxy API. Supports Ed25519 wallet operations.
 author: Pi-Squared-Inc
 homepage: https://github.com/Pi-Squared-Inc/fastset-rpc-docs
@@ -9,6 +9,31 @@ homepage: https://github.com/Pi-Squared-Inc/fastset-rpc-docs
 # FastSet Network Skill
 
 Interact with the FastSet network via the JSON-RPC proxy API at `https://proxy.fastset.xyz`.
+
+## Prerequisites
+
+**npm packages** (for TypeScript/Node.js):
+```bash
+npm install @mysten/bcs @noble/ed25519 @noble/hashes
+```
+
+**Required setup** — `@noble/ed25519` needs an explicit SHA-512 implementation:
+```typescript
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha2";
+ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
+```
+
+**BigInt JSON serialization** workaround (needed for JSON-RPC calls):
+```typescript
+// @ts-ignore
+BigInt.prototype.toJSON = function () { return Number(this); };
+```
+
+**Uint8Array → JSON**: When serializing `Uint8Array` to JSON, use `Array.from(bytes)` — `JSON.stringify` doesn't handle typed arrays natively:
+```typescript
+JSON.stringify(data, (k, v) => v instanceof Uint8Array ? Array.from(v) : v);
+```
 
 ## Quick Reference
 
@@ -22,10 +47,52 @@ Interact with the FastSet network via the JSON-RPC proxy API at `https://proxy.f
 ## Core Concepts
 
 - **Addresses**: 32-byte Ed25519 public keys — sent as JSON arrays of 32 unsigned integers (byte arrays), not hex strings
-- **Nonce**: Auto-incrementing u64 per account (start at 0)
-- **Amounts**: Hex-encoded 256-bit integers (e.g., `"ffff"` = 65535)
-- **Native Token ID**: `FA575E7000000000000000000000000000000000000000000000000000000000`
-- **Signatures**: Ed25519 over `"Transaction::" + BCS(transaction)` (BCS encodes Amount/Balance fields as 32-byte little-endian u256)
+- **Nonce**: Auto-incrementing `u64` per account (start at 0). Fetch current value from `proxy_getAccountInfo` → `next_nonce`
+- **Amounts**: Hex-encoded 256-bit integers in JSON (e.g., `"ffff"` = 65535). **BCS encodes these as 32-byte little-endian u256** — the `@mysten/bcs` transform handles this automatically (see BCS Types section)
+- **Timestamps**: `timestamp_nanos` is a `u128` (use `BigInt` in TypeScript)
+- **Native Token ID**: `FA575E7000000000000000000000000000000000000000000000000000000000` (as bytes: `[0xfa, 0x57, 0x5e, 0x70, 0, 0, ..., 0]`)
+- **Signatures**: Ed25519 over `"Transaction::" + BCS(transaction)`
+
+## BCS Type Definitions
+
+These are required for transaction signing. The BCS schema must match the on-chain types exactly.
+
+```typescript
+import { bcs } from "@mysten/bcs";
+
+const Bytes32 = bcs.bytes(32);
+const Bytes64 = bcs.bytes(64);
+
+// Amount: hex string in JSON, but BCS encodes as u256 (32-byte LE)
+const AmountBcs = bcs.u256().transform({
+  input: (val) => BigInt(`0x${val}`).toString(), // hex → decimal for BCS
+});
+
+const TokenTransfer = bcs.struct("TokenTransfer", {
+  token_id: Bytes32,
+  amount: AmountBcs,
+  user_data: bcs.option(Bytes32),
+});
+
+// ClaimType enum — variant order matters for BCS encoding!
+// Index 0 = TokenTransfer. Other variants exist but are omitted here.
+const ClaimType = bcs.enum("ClaimType", {
+  TokenTransfer: TokenTransfer,
+});
+
+const TransactionBcs = bcs.struct("Transaction", {
+  sender: Bytes32,
+  recipient: Bytes32,
+  nonce: bcs.u64(),
+  timestamp_nanos: bcs.u128(),
+  claim: ClaimType,
+  archival: bcs.bool(),
+});
+```
+
+> **Important**: The `ClaimType` enum variant ordering determines the BCS discriminant byte.
+> `TokenTransfer` = index 0. If you add more variants (TokenCreation, TokenManagement, Mint, ExternalClaim, Batch),
+> they must match the on-chain ordering. See `typescript-examples/fastset-types.ts` for the complete set.
 
 ## Common Operations
 
@@ -47,10 +114,13 @@ curl -X POST https://proxy.fastset.xyz \
   }'
 ```
 
-> **Note**: `address` is a JSON array of 32 unsigned integers (the bytes of the Ed25519 public key).  
+> **Note**: `address` is a JSON array of 32 unsigned integers (the bytes of the Ed25519 public key).
 > `token_balances_filter` (not `token_balance_filter`) accepts an array of token IDs or `null`.
 
-Response includes `balance` (hex string), `next_nonce`, and `token_balances` map.
+**Response fields**:
+- `balance` — hex string (e.g., `"de0b6b3a7640000"`)
+- `next_nonce` — integer, use this as nonce for the next transaction
+- `token_balances` — map of custom token balances (native balance is in `balance`, not here)
 
 ### 2. Get Test Tokens (Faucet)
 
@@ -69,64 +139,61 @@ curl -X POST https://proxy.fastset.xyz \
   }'
 ```
 
-> **Note**: `recipient` is a byte array (same format as address). `amount` is a hex string.  
-> `token_id` can be `null` (native token) or a 32-byte array for custom tokens.  
-> Returns `null` on success.
+> `recipient` is a byte array (same format as address). `amount` is a hex string.
+> `token_id` can be `null` (native token) or a 32-byte array for custom tokens.
+> **Returns `null` on success** (not a confirmation object).
 
 ### 3. Transfer Tokens
 
-Build a transaction with claim type `TokenTransfer`:
-
-```json
-{
-  "sender": [/* 32-byte pubkey */],
-  "recipient": [/* 32-byte pubkey */],
-  "nonce": 0,
-  "timestamp_nanos": 1700000000000000000,
-  "archival": false,
-  "claim": {
-    "TokenTransfer": {
-      "token_id": [/* 32-byte token ID */],
-      "amount": "ffff",
-      "user_data": null
-    }
-  }
-}
-```
-
-Sign with Ed25519 over: `"Transaction::" + BCS(transaction)`
-
-Submit via `proxy_submitTransaction` with `{ transaction, signature: { Signature: [/* 64 bytes */] } }`.
-
-## Claim Types
-
-| Type | Purpose |
-|------|---------|
-| `TokenTransfer` | Transfer tokens between accounts |
-| `TokenCreation` | Create new custom token |
-| `TokenManagement` | Modify token (admin, minters) |
-| `Mint` | Mint additional supply (authorized minters) |
-| `ExternalClaim` | Submit arbitrary data with verifier signatures |
-| `Batch` | Bundle multiple operations |
-
-## Transaction Signing (TypeScript)
+Build a transaction object:
 
 ```typescript
-import { bcs } from "@mysten/bcs";
-import * as ed from "@noble/ed25519";
+const transaction = {
+  sender: senderPubKey,          // Uint8Array (32 bytes)
+  recipient: recipientPubKey,    // Uint8Array (32 bytes)
+  nonce: nextNonce,              // number (from getAccountInfo)
+  timestamp_nanos: BigInt(Date.now()) * 1_000_000n,  // u128 nanoseconds
+  claim: {
+    TokenTransfer: {
+      token_id: SET_TOKEN_ID,    // Uint8Array (32 bytes)
+      amount: "ffff",            // hex string
+      user_data: null,
+    }
+  },
+  archival: false,
+};
+```
 
-// Define BCS schema for Transaction (see typescript-examples/fastset-types.ts)
+Sign and submit:
+
+```typescript
+// Sign
 const msghead = new TextEncoder().encode("Transaction::");
 const msgbody = TransactionBcs.serialize(transaction).toBytes();
 const msg = new Uint8Array(msghead.length + msgbody.length);
 msg.set(msghead, 0);
 msg.set(msgbody, msghead.length);
 const signature = ed.sign(msg, privateKey);
+
+// Submit via JSON-RPC
+const params = {
+  transaction,
+  signature: { Signature: signature }  // wraps in enum variant
+};
+// POST to proxy with method "proxy_submitTransaction" and params above
+// Remember to use the custom JSON serializer for Uint8Array → Array.from()
 ```
 
-## Transaction Signing (Rust)
+## Claim Types
 
-Use the `bcs` crate with `serde` for serialization. See `rust-examples/` for complete implementation.
+| Type | BCS Index | Purpose |
+|------|-----------|---------|
+| `TokenTransfer` | 0 | Transfer tokens between accounts |
+| `TokenCreation` | 1 | Create new custom token |
+| `TokenManagement` | 2 | Modify token (admin, minters) |
+| `Mint` | 3 | Mint additional supply (authorized minters) |
+| `ExternalClaim` | 4 | Submit arbitrary data with verifier signatures |
+| `Batch` | 5 | Bundle multiple operations |
 
 ## Wallet Management
 
@@ -134,8 +201,11 @@ Use the `bcs` crate with `serde` for serialization. See `rust-examples/` for com
 
 ```typescript
 import * as ed from "@noble/ed25519";
-const privateKey = ed.utils.randomPrivateKey(); // 32 bytes (or randomSecretKey() in newer versions)
-const publicKey = await ed.getPublicKeyAsync(privateKey); // 32 bytes = address
+import { sha512 } from "@noble/hashes/sha2";
+ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
+
+const privateKey = ed.utils.randomPrivateKey(); // 32 bytes
+const publicKey = ed.getPublicKey(privateKey);   // 32 bytes = your address
 ```
 
 ### Store Private Key Securely
@@ -145,13 +215,88 @@ Store as hex string in environment variable or secure vault:
 export FASTSET_PRIVATE_KEY="your_64_char_hex_private_key"
 ```
 
-## Working Examples
+## Complete Working Example
 
-Complete working examples are available:
-- **TypeScript**: `typescript-examples/` - Run with `npm install && npm run start`
-- **Rust**: `rust-examples/` - Run with `cargo run`
+Self-contained Node.js example — generate wallet, fund via faucet, transfer tokens:
 
-Both demonstrate: key generation → faucet funding → transaction signing → submission.
+```typescript
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha2";
+import { bcs } from "@mysten/bcs";
+
+// Setup
+ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
+// @ts-ignore
+BigInt.prototype.toJSON = function () { return Number(this); };
+
+const PROXY = "https://proxy.fastset.xyz";
+const SET_TOKEN_ID = new Uint8Array(32);
+SET_TOKEN_ID.set([0xfa, 0x57, 0x5e, 0x70], 0);
+
+// BCS types (minimal for TokenTransfer)
+const AmountBcs = bcs.u256().transform({
+  input: (val) => BigInt(`0x${val}`).toString(),
+});
+const TokenTransfer = bcs.struct("TokenTransfer", {
+  token_id: bcs.bytes(32), amount: AmountBcs, user_data: bcs.option(bcs.bytes(32)),
+});
+const ClaimType = bcs.enum("ClaimType", { TokenTransfer });
+const TransactionBcs = bcs.struct("Transaction", {
+  sender: bcs.bytes(32), recipient: bcs.bytes(32),
+  nonce: bcs.u64(), timestamp_nanos: bcs.u128(),
+  claim: ClaimType, archival: bcs.bool(),
+});
+
+// Helpers
+const toJSON = (data: any) => JSON.stringify(data, (k, v) =>
+  v instanceof Uint8Array ? Array.from(v) : v);
+
+async function rpc(method: string, params: any) {
+  const res = await fetch(PROXY, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: toJSON({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  return res.json();
+}
+
+// 1. Generate keypairs
+const sk1 = ed.utils.randomPrivateKey();
+const pk1 = ed.getPublicKey(sk1);
+const sk2 = ed.utils.randomPrivateKey();
+const pk2 = ed.getPublicKey(sk2);
+
+// 2. Fund sender via faucet
+await rpc("proxy_faucetDrip", { recipient: pk1, amount: "de0b6b3a7640000", token_id: null });
+
+// 3. Check balance & nonce
+const info = await rpc("proxy_getAccountInfo", {
+  address: pk1, token_balances_filter: null, state_key_filter: null, certificate_by_nonce: null,
+});
+console.log("Balance:", info.result.balance, "Nonce:", info.result.next_nonce);
+
+// 4. Build, sign, and submit a transfer
+const tx = {
+  sender: pk1, recipient: pk2, nonce: info.result.next_nonce,
+  timestamp_nanos: BigInt(Date.now()) * 1_000_000n,
+  claim: { TokenTransfer: { token_id: SET_TOKEN_ID, amount: "ffff", user_data: null } },
+  archival: false,
+};
+const head = new TextEncoder().encode("Transaction::");
+const body = TransactionBcs.serialize(tx).toBytes();
+const msg = new Uint8Array(head.length + body.length);
+msg.set(head, 0); msg.set(body, head.length);
+const sig = ed.sign(msg, sk1);
+
+const result = await rpc("proxy_submitTransaction", {
+  transaction: tx, signature: { Signature: sig },
+});
+console.log("Transfer result:", result);
+```
+
+## Transaction Signing (Rust)
+
+Use the `bcs` crate with `serde` for serialization. See `rust-examples/` for complete implementation.
 
 ## Error Handling
 
@@ -160,6 +305,7 @@ Both demonstrate: key generation → faucet funding → transaction signing → 
 | Invalid nonce | Wrong sequence number | Fetch `next_nonce` from `proxy_getAccountInfo` |
 | Insufficient balance | Not enough tokens | Use faucet or receive transfer first |
 | Invalid signature | Wrong signing process | Ensure BCS encoding with `"Transaction::"` prefix |
+| `No more params` | Missing required RPC parameters | Check all required fields are present |
 
 ## API Reference
 

--- a/skills/fastset/SKILL.md
+++ b/skills/fastset/SKILL.md
@@ -142,9 +142,60 @@ const TokenTransfer = bcs.struct("TokenTransfer", {
   user_data: bcs.option(bcs.bytes(32)),
 });
 
+const TokenCreation = bcs.struct("TokenCreation", {
+  token_name: bcs.string(),
+  decimals: bcs.u8(),
+  initial_amount: AmountBcs,
+  mints: bcs.vector(bcs.bytes(32)),
+  user_data: bcs.option(bcs.bytes(32)),
+});
+
+const AddressChange = bcs.enum("AddressChange", {
+  Add: bcs.tuple([]),
+  Remove: bcs.tuple([]),
+});
+
+const TokenManagement = bcs.struct("TokenManagement", {
+  token_id: bcs.bytes(32),
+  update_id: bcs.u64(), 
+  new_admin: bcs.option(bcs.bytes(32)),
+  mints: bcs.vector(bcs.tuple([AddressChange, bcs.bytes(32)])),
+  user_data: bcs.option(bcs.bytes(32)),
+});
+
+const Mint = bcs.struct("Mint", {
+  token_id: bcs.bytes(32),
+  amount: AmountBcs,
+});
+
 // Variant order matters for BCS! TokenTransfer = index 0.
 const ClaimType = bcs.enum("ClaimType", {
   TokenTransfer: TokenTransfer,
+  TokenCreation: TokenCreation,
+  TokenManagement: TokenManagement,
+  Mint: Mint,
+  StateInitialization: bcs.struct("StateInitialization", { dummy: bcs.u8() }),
+  StateUpdate: bcs.struct("StateUpdate", { dummy: bcs.u8() }),
+  ExternalClaim: bcs.struct("ExternalClaim", { data: bcs.bytes(32) }),
+  StateReset: bcs.struct("StateReset", { dummy: bcs.u8() }),
+  JoinCommittee: bcs.struct("JoinCommittee", { dummy: bcs.u8() }),
+  LeaveCommittee: bcs.struct("LeaveCommittee", { dummy: bcs.u8() }),
+  ChangeCommittee: bcs.struct("ChangeCommittee", { dummy: bcs.u8() }),
+  Batch: bcs.vector(bcs.enum("Operation", {
+      TokenTransfer: bcs.struct("TokenTransferOperation", {
+          token_id: bcs.bytes(32),
+          recipient: bcs.bytes(32),
+          amount: AmountBcs,
+          user_data: bcs.option(bcs.bytes(32))
+      }),
+      TokenCreation: TokenCreation,
+      TokenManagement: TokenManagement,
+      Mint: bcs.struct("MintOperation", {
+          token_id: bcs.bytes(32),
+          recipient: bcs.bytes(32),
+          amount: AmountBcs
+      })
+  }))
 });
 
 const TransactionBcs = bcs.struct("Transaction", {

--- a/typescript-examples/fastset-types.ts
+++ b/typescript-examples/fastset-types.ts
@@ -1,6 +1,7 @@
 import { bcs, BcsType, type InferBcsInput } from "@mysten/bcs";
 import * as ed from "@noble/ed25519";
 import { sha512 } from "@noble/hashes/sha2";
+import { keccak_256 } from "@noble/hashes/sha3";
 import * as util from "util";
 
 export {
@@ -11,6 +12,7 @@ export {
     proxy_getAccountInfo,
     proxy_submitTransaction,
     proxy_faucetDrip,
+    computeTokenId,
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -77,7 +79,12 @@ const AmountBcs = bcs.u256().transform({
     // CAUTION: When we build a transaction object, we must use a hex encoded string because the
     // validator expects amounts to be in hex. However, bcs.u256() by default expects a decimal
     // string. Therefore, we must transform the input amount from hex to decimal here.
-    input: (val) => hexToDecimal(val.toString()),
+    input: (val) => {
+        if (typeof val === 'string' && val.startsWith('0x')) {
+            return BigInt(val).toString();
+        }
+        return hexToDecimal(val.toString());
+    },
 });
 type Amount = InferBcsInput<typeof AmountBcs>;
 
@@ -97,15 +104,87 @@ const TokenTransfer = bcs.struct("TokenTransfer", {
     user_data: UserData,
 });
 
+const TokenCreation = bcs.struct("TokenCreation", {
+    token_name: bcs.string(),
+    decimals: bcs.u8(),
+    initial_amount: AmountBcs,
+    mints: bcs.vector(bcs.bytes(32)),
+    user_data: bcs.option(bcs.bytes(32)),
+});
+
+// AddressChange for TokenManagement
+// Verified via testing: AddressChange must be a tuple variant
+const AddressChange = bcs.enum("AddressChange", {
+    Add: bcs.tuple([]),
+    Remove: bcs.tuple([]),
+});
+
+const TokenManagement = bcs.struct("TokenManagement", {
+    token_id: bcs.bytes(32),
+    update_id: bcs.u64(), 
+    new_admin: bcs.option(bcs.bytes(32)),
+    mints: bcs.vector(bcs.tuple([AddressChange, bcs.bytes(32)])),
+    user_data: bcs.option(bcs.bytes(32)),
+});
+
+const Mint = bcs.struct("Mint", {
+    token_id: bcs.bytes(32),
+    amount: AmountBcs,
+});
+
+const ExternalClaim = bcs.struct("ExternalClaim", {
+    data: bcs.bytes(32) 
+});
+
+// Operations for Batch
+const TokenTransferOperation = bcs.struct("TokenTransferOperation", {
+    token_id: bcs.bytes(32),
+    recipient: bcs.bytes(32),
+    amount: AmountBcs,
+    user_data: bcs.option(bcs.bytes(32))
+});
+
+const MintOperation = bcs.struct("MintOperation", {
+    token_id: bcs.bytes(32),
+    recipient: bcs.bytes(32),
+    amount: AmountBcs
+});
+
+// Operation Enum
+const Operation = bcs.enum("Operation", {
+    TokenTransfer: TokenTransferOperation,
+    TokenCreation: TokenCreation, 
+    TokenManagement: TokenManagement,
+    Mint: MintOperation,
+    // Placeholders to maintain index alignment if other variants exist in Rust enum
+    StateInitialization: bcs.struct("StateInitialization", { dummy: bcs.u8() }),
+    StateUpdate: bcs.struct("StateUpdate", { dummy: bcs.u8() }),
+    ExternalClaim: bcs.struct("ExternalClaim", { dummy: bcs.u8() }),
+    StateReset: bcs.struct("StateReset", { dummy: bcs.u8() }),
+    JoinCommittee: bcs.struct("JoinCommittee", { dummy: bcs.u8() }),
+    LeaveCommittee: bcs.struct("LeaveCommittee", { dummy: bcs.u8() }),
+    ChangeCommittee: bcs.struct("ChangeCommittee", { dummy: bcs.u8() }),
+});
+
+const Batch = bcs.vector(Operation);
+
 // ============================
 // We now define the claim type
 // ============================
 
-// A "claim" is a concept on FastSet that drives state changes on the FastSet network. It is akin to
-// the "calldata" of a transaction on Ethereum. There are many types of claims, but in this example,
-// others are omitted since we are interested in the Transfer claim.
 const ClaimType = bcs.enum("ClaimType", {
     TokenTransfer: TokenTransfer,
+    TokenCreation: TokenCreation,
+    TokenManagement: TokenManagement,
+    Mint: Mint,
+    StateInitialization: bcs.struct("StateInitialization", { dummy: bcs.u8() }), // Placeholder
+    StateUpdate: bcs.struct("StateUpdate", { dummy: bcs.u8() }), // Placeholder
+    ExternalClaim: ExternalClaim,
+    StateReset: bcs.struct("StateReset", { dummy: bcs.u8() }), // Placeholder
+    JoinCommittee: bcs.struct("JoinCommittee", { dummy: bcs.u8() }), // Placeholder
+    LeaveCommittee: bcs.struct("LeaveCommittee", { dummy: bcs.u8() }), // Placeholder
+    ChangeCommittee: bcs.struct("ChangeCommittee", { dummy: bcs.u8() }), // Placeholder
+    Batch: Batch
 });
 
 // =======================================================
@@ -148,7 +227,7 @@ const ProxySubmitTransactionResult = bcs.enum("ProxySubmitTransactionResult", {
 async function proxy_getAccountInfo(url: string, address: Address): Promise<any> {
     const response = await request(url, "proxy_getAccountInfo", {
         address,
-        token_balance_filter: null,
+        token_balances_filter: [],
         certificate_by_nonce: null,
     });
     return response;
@@ -277,4 +356,13 @@ function makeSignature(signing_key: ed.Bytes, type: BcsType<any>, value: any): S
 
 function signTransaction(signing_key: ed.Bytes, value: Transaction): SignatureOrMultiSig {
     return makeSignature(signing_key, TransactionBcs, value);
+}
+
+function computeTokenId(tx: any) {
+    const head = new TextEncoder().encode("Transaction::");
+    const body = TransactionBcs.serialize(tx).toBytes();
+    const msg = new Uint8Array(head.length + body.length);
+    msg.set(head, 0);
+    msg.set(body, head.length);
+    return keccak_256(msg);
 }

--- a/typescript-examples/package-lock.json
+++ b/typescript-examples/package-lock.json
@@ -266,7 +266,8 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
             "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",

--- a/typescript-examples/test_skill.ts
+++ b/typescript-examples/test_skill.ts
@@ -1,0 +1,168 @@
+import * as ed from "@noble/ed25519";
+import { 
+    SET_TOKEN_ID, 
+    proxy_getAccountInfo, 
+    proxy_faucetDrip, 
+    proxy_submitTransaction, 
+    computeTokenId, 
+    signTransaction,
+    randomPrivateKey,
+    getPublicKey
+} from "./fastset-types";
+import { bcs } from "@mysten/bcs";
+
+// --- Helpers ---
+const toHexString = (bytes: Uint8Array) =>
+  bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, "0"), "");
+
+// --- Main ---
+async function main() {
+  console.log("🚀 Starting FastSet Skill Test...");
+
+  // 1. Wallet Management
+  console.log("\n--- 1. Wallet Management ---");
+  const sk1 = randomPrivateKey();
+  const pk1 = getPublicKey(sk1);
+  const sk2 = randomPrivateKey();
+  const pk2 = getPublicKey(sk2);
+  
+  console.log("Generated Wallet 1 PK:", toHexString(pk1));
+  console.log("Generated Wallet 2 PK:", toHexString(pk2));
+
+  // 2. Faucet & Balance
+  console.log("\n--- 2. Faucet & Balance ---");
+  const PROXY = "https://proxy.fastset.xyz";
+  
+  await proxy_faucetDrip(PROXY, pk1, "de0b6b3a7640000", null);
+  
+  let info1 = await proxy_getAccountInfo(PROXY, pk1);
+  for(let i=0; i<3; i++) {
+    if(info1.result && info1.result.balance !== "0") break;
+    await new Promise(r => setTimeout(r, 1000));
+    info1 = await proxy_getAccountInfo(PROXY, pk1);
+  }
+  console.log("Wallet 1 Balance:", info1.result?.balance);
+  let nonce = info1.result?.next_nonce || 0;
+
+  // 3. Transfer
+  console.log("\n--- 3. Transfer ---");
+  const txTransfer = {
+    sender: pk1, recipient: pk2, nonce: nonce,
+    timestamp_nanos: BigInt(Date.now()) * 1_000_000n,
+    claim: { TokenTransfer: { token_id: SET_TOKEN_ID, amount: "ffff", user_data: null } },
+    archival: false,
+  };
+  
+  let sig = signTransaction(sk1, txTransfer);
+  let res = await proxy_submitTransaction(PROXY, txTransfer, sig);
+  console.log("Transfer:", res.result ? "✅ Success" : "❌ Failed " + JSON.stringify(res.error));
+  if(res.result) nonce++;
+
+  // 4. Token Creation
+  console.log("\n--- 4. Token Creation ---");
+  const txCreate = {
+    sender: pk1, recipient: pk1, nonce: nonce,
+    timestamp_nanos: BigInt(Date.now()) * 1_000_000n,
+    claim: {
+        TokenCreation: {
+            token_name: "TestToken",
+            decimals: 18,
+            initial_amount: "1000000",
+            mints: [pk1],
+            user_data: null,
+        }
+    },
+    archival: false
+  };
+
+  sig = signTransaction(sk1, txCreate);
+  res = await proxy_submitTransaction(PROXY, txCreate, sig);
+  console.log("Token Creation:", res.result ? "✅ Success" : "❌ Failed " + JSON.stringify(res.error));
+  
+  let newTokenId: Uint8Array | null = null;
+  if (res.result) {
+      info1 = await proxy_getAccountInfo(PROXY, pk1);
+      for(let i=0; i<3; i++) {
+        if(info1.result && info1.result.token_balance && info1.result.token_balance.length > 0) break;
+        await new Promise(r => setTimeout(r, 1000));
+        info1 = await proxy_getAccountInfo(PROXY, pk1);
+      }
+      
+      if (info1.result && info1.result.token_balance.length > 0) {
+          const rawTokenId = info1.result.token_balance[0][0];
+          newTokenId = new Uint8Array(rawTokenId);
+          console.log("New Token ID (fetched):", toHexString(newTokenId));
+      } else {
+          console.log("⚠️ Could not find new token in account balance.");
+      }
+      nonce++;
+  }
+
+  if (newTokenId) {
+      // 5. Mint
+      console.log("\n--- 5. Mint ---");
+      const txMint = {
+        sender: pk1, recipient: pk1, nonce: nonce,
+        timestamp_nanos: BigInt(Date.now()) * 1_000_000n,
+        claim: {
+            Mint: {
+                token_id: newTokenId,
+                amount: "100",
+            }
+        },
+        archival: false
+      };
+      
+      sig = signTransaction(sk1, txMint);
+      res = await proxy_submitTransaction(PROXY, txMint, sig);
+      console.log("Mint:", res.result ? "✅ Success" : "❌ Failed " + JSON.stringify(res.error));
+      if(res.result) nonce++;
+
+      // 6. Token Management (Add Minter)
+      console.log("\n--- 6. Token Management ---");
+      const txManage = {
+        sender: pk1, recipient: pk1, nonce: nonce,
+        timestamp_nanos: BigInt(Date.now()) * 1_000_000n,
+        claim: {
+            TokenManagement: {
+                token_id: newTokenId,
+                update_id: 0, 
+                new_admin: null,
+                mints: [ [{Add: []}, pk2] ], 
+                user_data: null
+            }
+        },
+        archival: false
+      };
+      
+      sig = signTransaction(sk1, txManage);
+      res = await proxy_submitTransaction(PROXY, txManage, sig);
+      console.log("Token Management:", res.result ? "✅ Success" : "❌ Failed " + JSON.stringify(res.error));
+      if(res.result) nonce++;
+  }
+
+  // 7. Batch
+  console.log("\n--- 7. Batch ---");
+  if (newTokenId) {
+    const txBatch = {
+        sender: pk1, recipient: pk1, 
+        nonce: nonce,
+        timestamp_nanos: BigInt(Date.now()) * 1_000_000n,
+        claim: {
+            Batch: [
+                { TokenTransfer: { token_id: SET_TOKEN_ID, recipient: pk2, amount: "10", user_data: null } },
+                { TokenTransfer: { token_id: newTokenId, recipient: pk2, amount: "10", user_data: null } }
+            ]
+        },
+        archival: false
+    };
+
+    sig = signTransaction(sk1, txBatch);
+    res = await proxy_submitTransaction(PROXY, txBatch, sig);
+    console.log("Batch:", res.result ? "✅ Success" : "❌ Failed " + JSON.stringify(res.error));
+  }
+
+  console.log("\nDone.");
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Add FastSet OpenClaw Skill

Adds `skills/fastset/SKILL.md` — an [OpenClaw](https://openclaw.ai)-compatible skill definition for interacting with the FastSet JSON-RPC proxy API.

### Format

Follows the [OpenClaw Skills format](https://github.com/openclaw/skills) with YAML frontmatter (`name`, `version`, `description`, `author`, `homepage`) and structured Markdown instructions.

### Coverage

- **Endpoints**: `proxy_getAccountInfo`, `proxy_submitTransaction`, `proxy_faucetDrip`, `proxy_getTokenInfo`
- **Transaction signing**: Ed25519 + BCS serialization with `"Transaction::"` prefix
- **Claim types**: TokenTransfer, TokenCreation, TokenManagement, Mint, ExternalClaim, Batch
- **Wallet management**: Key generation, secure storage
- **Error handling**: Common errors and fixes
- **Examples**: References to existing TypeScript and Rust examples in the repo

### Usage

Install as an OpenClaw skill — the agent will auto-discover and load it when tasks involve FastSet operations.